### PR TITLE
Fix: Use correct API key for weather data

### DIFF
--- a/script.js
+++ b/script.js
@@ -170,9 +170,9 @@ async function cleanAndParseData(rawText) {
 async function getWeatherData(salesData) {
     const locationKey = locationEl.value;
     const coords = cityCoordinates[locationKey];
-    const API_KEY = "YOUR_API_KEY_HERE"; // <<-- Sett inn din API-nøkkel her
+    const API_KEY = apiKey; // <<-- Bruker den globale API-nøkkelen
     
-    if (API_KEY === "YOUR_API_KEY_HERE" || !coords) {
+    if (!API_KEY || !coords) {
         throw new Error("Vennligst oppgi en gyldig OpenWeatherMap API-nøkkel i script.js og velg et gyldig område.");
     }
 


### PR DESCRIPTION
The 'analyser data' button was not working because the OpenWeatherMap API call was using a placeholder API key. This change corrects the issue by using the globally defined API key.

Additionally, the conditional check for the API key's presence has been updated to work correctly with the new variable.