### PR TITLE
Fix Gemini API 400 Bad Request error

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,7 +134,7 @@ async function cleanAndParseData(rawText) {
     let backoff = 1000;
     for (let i = 0; i < 5; i++) {
         try {
-            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
+            const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
             const response = await fetch(apiUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
The `gemini-2.5-flash-preview-05-20` model was causing a 400 Bad Request error. This is likely because the preview model is no longer available.

This commit changes the model to `gemini-pro`, which is a stable and generally available model. This should resolve the API error.