### PR TITLE
Fix CSV parsing to be more robust

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,8 +118,8 @@ async function parseFile(file) {
         }
     } else if (file.name.endsWith('.csv')) {
         try {
-            const lines = text.split('\\n').filter(line => line.trim() !== '');
-            const header = lines[0].split(',').map(h => h.trim());
+            const lines = text.split(/\r?\n/).filter(line => line.trim() !== '');
+            const header = lines[0].split(',').map(h => h.trim().toLowerCase());
             const dateIndex = header.indexOf('date');
             const salesIndex = header.indexOf('sales');
 


### PR DESCRIPTION
The CSV parsing logic was too strict and would fail if the line endings were not `\n` or if the column headers had different casing.

This change makes the parsing more robust by:
- Handling both `\n` and `\r\n` line endings.
- Making the header matching case-insensitive and trimming whitespace.